### PR TITLE
Install in /inst instead of /tmp/inst

### DIFF
--- a/msys2/appveyor-build-opensp.sh
+++ b/msys2/appveyor-build-opensp.sh
@@ -20,5 +20,5 @@ patch -s -p1 < opensp-1.5.2-msys2.patch
 
 echo "Initialise..."
 ./autoinit.sh
-./configure --prefix=/tmp/inst --disable-doc-build
+./configure --prefix=/inst --disable-doc-build
 make -j 2 && make install


### PR DESCRIPTION
This is needed for the build and use of Grisbi on Windows